### PR TITLE
Library code test with a watcher implementation

### DIFF
--- a/src/emptyepsilon.js
+++ b/src/emptyepsilon.js
@@ -1,0 +1,57 @@
+(() => {
+    const watchers = {};
+
+    window.EmptyEpsilon = {
+        get: params =>
+            fetch(
+                '/get.lua?' + 
+                Object.keys(params).map(key =>
+                    encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+                ).join('&')
+            )
+            .then(_ => _.json()),
+
+        set: params =>
+            fetch(
+                '/set.lua?' + 
+                Object.keys(params).map(key =>
+                    encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+                ).join('&')
+            )
+            .then(_ => _.json()),
+
+        exec: body =>
+            fetch('/exec.lua', {method: 'POST', body})
+            .then(_ => _.json()),
+
+
+        watch: expression => ({
+            onValue: callback => {
+                if (!watchers[expression]) {
+                    watchers[expression] = [];
+                }
+                watchers[expression].push(callback);
+            }
+        })
+    };
+
+    setInterval(() => {
+        const params = Object.keys(watchers).reduce(
+            (params, expression, index) => Object.assign(params, {[`q${index}`]: expression}),
+            {}
+        );
+
+        const result = EmptyEpsilon.get(params).then(data =>
+            Object.keys(params).map(key => {
+                const expression = params[key];
+                const value = data[key];
+                return {expression, value};
+            })
+        );
+        result.then(result => {
+            result.forEach(pair => {
+                watchers[pair.expression].forEach(watcher => watcher(pair.value));
+            });
+        });
+    }, 200);
+})();

--- a/src/tubes.html
+++ b/src/tubes.html
@@ -81,37 +81,34 @@ body {
 <div class="tubes">
 </div>
 
+
+<script src="emptyepsilon.js"></script>
 <script>
 
 const range = (start, end) => [...Array(end - start + 1)].map((_, i) => start + i);
 
 const types = ['homing', 'nuke', 'mine', 'emp'];
 
-const tubeCount = fetch('/get.lua?tubeCount=getWeaponTubeCount()').then(_ => _.json()).then(_ => _.tubeCount);
-
-const tubes = (tubeCount) => {
-  const tubes = range(0, tubeCount - 1);
-
-  const url = '/get.lua?' + tubes.map(tube => `tube${tube}=getWeaponTubeLoadType(${tube})`).join('&');
-  fetch(url).then(response => response.json()).then(data => {
-    document.querySelector('.tubes').innerHTML = tubes.map(tube => {
-      const content = data['tube' + tube] || 'empty';
-      return `<div>Tube ${tube}: ${content}</div>`;
-    }).join('')
-  });
-};
+const tubeCount = EmptyEpsilon.get({tubeCount: 'getWeaponTubeCount()'}).then(_ => _.tubeCount);
 
 tubeCount.then(tubeCount => {
-  setInterval(() => tubes(tubeCount), 200);
-});
+  const tubes = range(0, tubeCount - 1);
 
-setInterval(() => {
-  const url = '/get.lua?' + types.map(type => `${type}=getWeaponStorage("${type}")`).join('&');
-  fetch(url).then(_ => _.json()).then(data => {
-    types.forEach(type => {
-      document.querySelector('.' + type).innerText = data[type];
+  document.querySelector('.tubes').innerHTML = tubes.map(tube => {
+    return `<div class="tube${tube}">Tube ${tube}: loading</div>`;
+  }).join('');
+
+  tubes.forEach(tube => {
+    EmptyEpsilon.watch(`getWeaponTubeLoadType(${tube})`).onValue(value => {
+      document.querySelector(`.tube${tube}`).innerText = `Tube ${tube}: ${value || 'empty'}`;
     });
   });
-}, 200);
+});
+
+types.forEach(type => {
+  EmptyEpsilon.watch(`getWeaponStorage("${type}")`).onValue(value => {
+    document.querySelector('.' + type).innerText = value;
+  });
+});
 
 </script>


### PR DESCRIPTION
- `EmptyEpsilon.set`, `EmptyEpsilon.exec` untested
- Do we want a library like this? Would it be better to just use base api with `fetch`?
  - Code clarity
  - Learning
  - Ease of use
  - Performance
- What kind of API do we want?
- Would it be better to do the watch stuff via exec?
- TODO closing watchers
- TODO refactor watcher implementation, better naming
- TODO delayed one-time get in next watch cycle?
